### PR TITLE
Allow sku, increment_id instead of entity_id

### DIFF
--- a/code/Model/Observer.php
+++ b/code/Model/Observer.php
@@ -38,6 +38,23 @@ class BlueAcorn_UniversalAnalytics_Model_Observer extends Mage_Core_Model_Observ
     }
     
     /**
+     * Before main entry point when loading a product collection.
+     * Ensures attributes are added to the collection.
+     *
+     * @name viewProductCollection
+     * @param observer $observer
+     */
+    public function viewProductBeforeCollection($observer) {
+        // Lock down this function in order to prevent infinite
+        // recursion loops
+        if ($this->lockObserver('collection')) return;
+
+        $observer->getCollection()->addAttributeToSelect('sku');
+
+        $this->unlockObserver('collection');
+    }
+
+    /**
      * Main entry point when loading a product collection. Generates a
      * $listName and then passes the products to the monitor to be
      * added as product impressions.

--- a/code/etc/config.xml
+++ b/code/etc/config.xml
@@ -36,6 +36,16 @@
 		</observers>
 	    </catalog_product_load_after>
 
+	    <catalog_product_collection_load_before>
+		<observers>
+		    <baua>
+			<type>model</type>
+			<class>baua/observer</class>
+			<method>viewProductBeforeCollection</method>
+		    </baua>
+		</observers>
+	    </catalog_product_collection_load_before>
+
 	    <catalog_product_collection_load_after>
 		<observers>
 		    <baua>

--- a/code/etc/config.xml
+++ b/code/etc/config.xml
@@ -85,7 +85,7 @@
             </settings>
             <translation>
                 <addImpression>
-                    <id>entity_id</id>
+                    <id>sku</id>
                     <name>name</name>
                     <brand>manufacturer</brand>
                     <category>category_collection</category>
@@ -103,7 +103,7 @@
                     <name>name</name>
                 </addPromo>
                 <addProduct>
-                    <id>entity_id</id>
+                    <id>sku</id>
                     <name>name</name>
                     <category>category_collection</category>
                     <brand>manufacturer</brand>
@@ -149,7 +149,7 @@
                     <product_type>product_type</product_type>
                 </capturetransactionitems>
                 <transaction>
-                    <entity_id>id</entity_id>
+                    <increment_id>id</increment_id>
                     <store_name>affiliation</store_name>
                     <base_grand_total>revenue</base_grand_total>
                     <tax_amount>tax</tax_amount>


### PR DESCRIPTION
In Google Analytics we use `sku` for products and `increment_id` for orders.

I see some of that info is able to be adjusted by changing etc/config.xml, but this only works for some.

Within `<transaction>`, changing `<entity_id>id</entity_id>` to `<increment_id>id</increment_id>` works. Within `<addProduct>`, changing `<id>entity_id</id>` to `<id>sku</id>` works. But, within `<addImpression>`, making the same `sku` change doesn't work (`id` does not show in generated JS output) because the Collection being used doesn't include the `sku`.

An option to customize which `id` is used for different types would be convenient. Any workaround suggestion?