### PR TITLE
Remove setCacheLifetime from onestepcheckout block

### DIFF
--- a/frontend/layout/blueacorn/universalanalytics.xml
+++ b/frontend/layout/blueacorn/universalanalytics.xml
@@ -28,11 +28,7 @@
     <checkout_onepage_index>
         <reference name="before_body_end" before="-">
             <block type="core/template" name="universalanalytics_checkout" as="universalanalytics_checkout"
-                template="blueacorn/universalanalytics/onestepcheckout.phtml">
-		<action method="setCacheLifetime">
-		    <time>null</time>
-		</action>
-	    </block>
+                template="blueacorn/universalanalytics/onestepcheckout.phtml" />
         </reference>
     </checkout_onepage_index>
     <checkout_onepage_success>


### PR DESCRIPTION
Magento reads the null value as a string. Which actually sets a cache lifetime. This has the opposite effect as desired. By default, a core/template block doesn't have a cache lifetime anyway. Therefor, setting it is unneeded for the desired effect.

I confirmed this block was being cached by adding `<?php echo date('r'); ?>` to the end of the file, and seeing the timestamp never changed. Also adding/removing items from the cart would persist items on the checkout.

I am using Redis as the cache backend by the way.