### PR TITLE
Bugfix/reload progress block

### DIFF
--- a/frontend/template/blueacorn/universalanalytics/onestepcheckout.phtml
+++ b/frontend/template/blueacorn/universalanalytics/onestepcheckout.phtml
@@ -1,4 +1,4 @@
-<!--- Universal Analytics Start --->
+<!-- Universal Analytics Start -->
 <?php $this->JS = Mage::getSingleton('baua/js'); ?>
 <?php $itemsCollection = Mage::getSingleton('checkout/session')->getQuote()->getItemsCollection(); ?>
 <?php $_helper = Mage::helper('baua') ?>
@@ -68,9 +68,9 @@
             // that functionality here.
             this.currentStep = section;
 
-            this.gotoSectionparent(section);
+            this.gotoSectionparent(section, reloadProgressBlock);
         };
     </script>
 
 <?php endif ?>
-<!--- Universal Analytics End --->
+<!-- Universal Analytics End -->

--- a/frontend/template/blueacorn/universalanalytics/onestepcheckout.phtml
+++ b/frontend/template/blueacorn/universalanalytics/onestepcheckout.phtml
@@ -1,4 +1,4 @@
-<!-- Universal Analytics Start -->
+<!--- Universal Analytics Start -->
 <?php $this->JS = Mage::getSingleton('baua/js'); ?>
 <?php $itemsCollection = Mage::getSingleton('checkout/session')->getQuote()->getItemsCollection(); ?>
 <?php $_helper = Mage::helper('baua') ?>
@@ -63,14 +63,18 @@
             <?php endforeach; ?>
             <?php echo $this->JS->generateGoogleJS('send', 'pageview')?>
 
+            if (reloadProgressBlock) {
+                this.reloadProgressBlock(this.currentStep);
+            }
+
             // Older versions of Magento are completely lacking the
             // currentStep variable, so we're re-implementing some of
             // that functionality here.
             this.currentStep = section;
 
-            this.gotoSectionparent(section, reloadProgressBlock);
+            this.gotoSectionparent(section);
         };
     </script>
 
 <?php endif ?>
-<!-- Universal Analytics End -->
+<!--- Universal Analytics End -->


### PR DESCRIPTION
@Skrath @briceburg @babobby @twslade 
Fixed an issue where the Progress Block in the Checkout was not always reloading properly, this was due to this.currentStep being set to section before the Progress Block was set to be loaded.  Originally I thought the issue was that reloadProgress was not being passed to gotoSectionparent method but that was still being called after this.currentStep was being set to section, instead passing in reloadProgressBlock I'm instead calling it earlier which from the looks of the code was originally the intent.