### PR TITLE
#23 Replace forEach with each

### DIFF
--- a/code/Model/Js.php
+++ b/code/Model/Js.php
@@ -20,7 +20,7 @@ class BlueAcorn_UniversalAnalytics_Model_Js {
     }
 
     /**
-     * Generate a forEach loop that calls an anonymous function
+     * Generate a each loop that calls an anonymous function
      * containing $content
      *
      * @name each
@@ -28,7 +28,7 @@ class BlueAcorn_UniversalAnalytics_Model_Js {
      * @return string
      */
     public function each($content) {
-        $text = '.forEach( ';
+        $text = '.each( ';
         $text .= $this->anonFunc('element, index, array', $content);
         $text .= ');';
 


### PR DESCRIPTION
Replacing `forEach` with `each` fixes compatibility issues with IE8. `forEach` is a ECMAScript 5 method, which isn't supported in IE8.

Fixes #23