### PR TITLE
Convert coupon codes to uppercase before submitting to GA

### DIFF
--- a/code/Model/Monitor.php
+++ b/code/Model/Monitor.php
@@ -401,7 +401,8 @@ class BlueAcorn_UniversalAnalytics_Model_Monitor {
             $newValue = $this->$method($product, $attribute);
             if ($newValue !== null) break;
         }
-
+        
+        $newValue = ($attribute == 'coupon_code') ? strtoupper($newValue) : $newValue;
         $newValue = str_replace(array("\n", "\t", "\r"), ' ', $newValue);
 
         return $newValue;


### PR DESCRIPTION
Coupon codes are not case sensitive in Magento, but Google Analytics will store data for coupon codes separately if they are submitted with varying capitalization (e.g. it considers "holiday5" different from "Holiday5"). I added this line to convert coupon codes to uppercase so that the same coupon will always be grouped together in GA, regardless of how the user enters it.