### PR TITLE
Debug mode + robust checkout

### DIFF
--- a/code/Helper/Data.php
+++ b/code/Helper/Data.php
@@ -132,4 +132,9 @@ class BlueAcorn_UniversalAnalytics_Helper_Data extends Mage_Core_Helper_Abstract
     {
         return (bool) Mage::getStoreConfig('google/baua/active');
     }
+
+    public function isDebugEnabled()
+    {
+        return (bool) Mage::getStoreConfig('google/baua/debug');
+    }
 }

--- a/code/Model/Js.php
+++ b/code/Model/Js.php
@@ -2,6 +2,19 @@
 
 class BlueAcorn_UniversalAnalytics_Model_Js {
 
+    protected $debug;
+
+    /**
+     * Constructor, sets up a shortcut variable for the main helper
+     * class.
+     *
+     * @name __construct
+     */
+    public function __construct() {
+        $this->helper = Mage::helper('baua');
+        $this->debug = $this->helper->isDebugEnabled();
+    }
+
     /**
      * Generate an observer for the specified $event which calls an
      * anonymous function containing the provided $content
@@ -64,12 +77,20 @@ class BlueAcorn_UniversalAnalytics_Model_Js {
         $params = func_get_args();
         $name = array_shift($params);
         $outputList = Array();
+        $result = '';
 
         foreach ($params as $element) {
             $outputList[] = Zend_Json::encode($element, false, array('enableJsonExprFinder' => true));
         }
 
-        return "{$name}(" . implode(', ', $outputList) . ");\n";
+        $debug = array('"send"', '"ec:setAction"');
+        if ($this->debug and in_array($outputList[0], $debug)) {
+            $result .= "console.log('GA: ".implode(', ', $outputList)."')\n";
+        }
+
+        $result .= "{$name}(" . implode(', ', $outputList) . ");\n";
+
+        return $result;
     }
 
     /**

--- a/code/etc/system.xml
+++ b/code/etc/system.xml
@@ -19,6 +19,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </active>
+                        <debug translate="label">
+                            <label>Debug</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>20</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </debug>
                     </fields>
                 </baua>
             </groups>

--- a/frontend/template/blueacorn/universalanalytics/onestepcheckout.phtml
+++ b/frontend/template/blueacorn/universalanalytics/onestepcheckout.phtml
@@ -2,6 +2,7 @@
 <?php $this->JS = Mage::getSingleton('baua/js'); ?>
 <?php $itemsCollection = Mage::getSingleton('checkout/session')->getQuote()->getItemsCollection(); ?>
 <?php $_helper = Mage::helper('baua') ?>
+<?php $_debug = $_helper->isDebugEnabled(); ?>
 <?php $productArray = array(); ?>
 <?php if($_helper->isActive()): ?>
     <?php foreach ($itemsCollection as $item) :?>
@@ -36,32 +37,57 @@
         */
         checkout.gotoSectionparent = checkout.gotoSection;
         checkout.gotoSection = function(section, reloadProgressBlock) {
+            try {
+                var curStep = this.steps.indexOf(this.currentStep)+1;
+                var nextStep = this.steps.indexOf(section)+1;
+                var option = undefined;
 
-            if (this.currentStep == 'login') {
-                ga('ec:setAction', 'checkout_option', {
-                    'step': this.steps.indexOf(this.currentStep)+1,
-                    'option': this.method
-                });
-                ga('send', 'event', 'Checkout', 'Option');
+                <?php if ($_debug): ?>
+                    console.log("ga gotoSection(" + section + ") from " + this.currentStep);
+                <?php endif; ?>
+
+                if (this.currentStep == 'login') {
+                    option = this.method;
+                }
+
+                if (this.currentStep == 'shipping_method') {
+                    option = $(shippingMethod.form).select('input[name="shipping_method"][checked]')[0];
+                    option = (typeof option == 'undefined') ? null : option.value;
+                }
+
+                if (typeof option !== 'undefined') {
+                    <?php if ($_debug): ?>
+                        console.log("ga('ec:setAction', 'checkout_option', {step: " + curStep + ", option: '" + option + "'})");
+                        console.log("ga('send', 'event', 'Checkout', 'Option')");
+                    <?php endif; ?>
+
+                    ga('ec:setAction', 'checkout_option', {
+                        'step': curStep,
+                        'option': option
+                    });
+                    ga('send', 'event', 'Checkout', 'Option');
+                } else {
+                    <?php if ($_debug): ?>
+                        console.log("ga unrecognized step `" + this.currentStep + "`");
+                    <?php endif; ?>
+                }
+
+                <?php if ($_debug): ?>
+                    console.log("ga('ec:setAction', 'checkout', {step: " + nextStep + ", label: " + section + "})");
+                <?php endif; ?>
+                ga('ec:setAction','checkout', {'step': nextStep, 'label': section });
+                <?php foreach($productArray as $product) : ?>
+                <?php echo $product; ?>
+                <?php endforeach; ?>
+                <?php echo $this->JS->generateGoogleJS('send', 'pageview')?>
+            } catch (e) {
+                <?php if ($_debug): ?>
+                try {
+                    console.log("Google analytics code failed");
+                    console.log(e);
+                } catch(e2) {}
+                <?php endif; ?>
             }
-
-            if (this.currentStep == 'shipping_method') {
-                shippingMethodOption = $(shippingMethod.form).select('input[name="shipping_method"][checked]')[0];
-                shippingMethodOption = (typeof shippingMethodOption == 'undefined') ? null : shippingMethodOption.value;
-
-                ga('ec:setAction', 'checkout_option', {
-                    'step': this.steps.indexOf(this.currentStep)+1,
-                    'option': shippingMethodOption
-                });
-                ga('send', 'event', 'Checkout', 'Option');
-            }
-
-
-            ga('ec:setAction','checkout', {'step': this.steps.indexOf(section)+1, 'label': section });
-            <?php foreach($productArray as $product) : ?>
-            <?php echo $product; ?>
-            <?php endforeach; ?>
-            <?php echo $this->JS->generateGoogleJS('send', 'pageview')?>
 
             if (reloadProgressBlock) {
                 this.reloadProgressBlock(this.currentStep);

--- a/frontend/template/blueacorn/universalanalytics/sitewideJs.phtml
+++ b/frontend/template/blueacorn/universalanalytics/sitewideJs.phtml
@@ -1,5 +1,6 @@
 <!-- Universal Analytics Start -->
 <?php $helper = Mage::helper('baua') ?>
+<?php $this->JS = Mage::getSingleton('baua/js'); ?>
 <?php if($helper->isActive()): ?>
      <script type="text/javascript">
 
@@ -20,7 +21,7 @@
          <?php echo $helper->generatePromoImpressions() ?>
 
          <?php echo $helper->getAction() ?>
-         ga('send', 'pageview');
+         <?php echo $this->JS->generateGoogleJS('send', 'pageview'); ?>
 
          <?php echo $helper->generateProductClickEvents() ?>
          <?php echo $helper->generatePromoClickEvents() ?>


### PR DESCRIPTION
Hi there,

This pull request enhance the code along two directions:

* A debug flag is available in Magento's config, to track ga calls. This is very handy when you doubt all necessary events will be properly tracked (e.g. the design breaks Magento standard practices, or uses lots of AJAX calls)
* I've made the checkout steps tracking robust, to avoid killing sales if something goes wrong.